### PR TITLE
sidebar-favourites

### DIFF
--- a/app/components/player-profile/favourite-button.tsx
+++ b/app/components/player-profile/favourite-button.tsx
@@ -1,0 +1,30 @@
+import { Button } from '../ui/button';
+import { Heart } from 'lucide-react';
+import { useFavourites } from '~/contexts/favourites';
+
+interface FavouriteButtonProps {
+  RSN: string;
+}
+
+export default function FavouriteProfileButton(props: Readonly<FavouriteButtonProps>) {
+  const { favourites, addFavourite, removeFavourite } = useFavourites();
+
+  const isFavourite = favourites.some((f) => f === props.RSN);
+
+  function toggleFavourite() {
+    if (isFavourite) removeFavourite(props.RSN);
+    else addFavourite(props.RSN);
+  }
+
+  return (
+    <Button
+      onClick={() => toggleFavourite()}
+      variant={isFavourite ? 'default' : 'outline'}
+      size="sm"
+      className="flex items-center gap-2 flex-1 sm:flex-none"
+    >
+      <Heart className={`h-4 w-4 ${isFavourite ? 'fill-current' : ''}`} />
+      <span className="hidden sm:inline">{isFavourite ? 'Favourited' : 'Favorite'}</span>
+    </Button>
+  );
+}

--- a/app/components/player-profile/profile.tsx
+++ b/app/components/player-profile/profile.tsx
@@ -6,6 +6,7 @@ import { Button } from '../ui/button';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '../ui/card';
 import { TableHeader, TableRow, TableHead, TableBody, TableCell, Table } from '../ui/table';
 import { Badge } from '../ui/badge';
+import FavouriteProfileButton from './favourite-button';
 
 interface ProfileProps {
   data: {
@@ -68,14 +69,7 @@ export default function PlayerProfile(props: Readonly<ProfileProps>) {
                 <RefreshCw className="h-4 w-4" />
                 <span className="hidden sm:inline">Refresh</span>
               </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                className="flex items-center gap-2 flex-1 sm:flex-none"
-              >
-                <Heart className={`h-4 w-4`} />
-                <span className="hidden sm:inline">Favourite</span>
-              </Button>
+              <FavouriteProfileButton RSN={player.data.name}/>
             </div>
           </div>
         </CardHeader>

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -19,6 +19,7 @@ import {
 import { Button } from '~/components/ui/button';
 import { NavLink, useNavigate } from '@remix-run/react';
 import { Card, CardContent } from './ui/card';
+import { useFavourites } from '~/contexts/favourites';
 
 const mainNavItems = [
   { title: 'Home', url: '/dashboard/index', icon: Home },
@@ -31,6 +32,7 @@ export default function DashboardSidebar() {
   const [selectedLanguage, setSelectedLanguage] = useState('EN');
   const collapsed = state === 'collapsed';
   const navigate = useNavigate();
+  const { favourites } = useFavourites();
 
   const handleFavouritesRedirect = (RSN: string) => navigate(`/dashboard/player/${RSN}`);
 
@@ -118,14 +120,19 @@ export default function DashboardSidebar() {
                   <span className="text-sm font-medium">Favourites</span>
                 </div>
                 <div className="space-y-1 text-xs text-muted-foreground">
-                  {/* this is an example user */}
-                  <div
-                    className="flex justify-between cursor-pointer hover:text-primary transition"
-                    onClick={() => handleFavouritesRedirect(`Kelcei`)}
-                  >
-                    <span>Kelcei</span>
-                    <span>2 hours ago</span>
-                  </div>
+                  {favourites.length === 0 ? (
+                    <>No favourites yet</>
+                  ) : (
+                    favourites.map((f) => (
+                      <div
+                        className="flex justify-between cursor-pointer hover:text-primary transition"
+                        onClick={() => handleFavouritesRedirect(f)}
+                      >
+                        <span>{f}</span>
+                        <span>2 hours ago</span>
+                      </div>
+                    ))
+                  )}
                 </div>
               </CardContent>
             </Card>

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, BookUser, Globe, Home, ListTodo } from 'lucide-react';
+import { BarChart3, BookUser, Globe, Heart, Home, ListTodo } from 'lucide-react';
 import { useState } from 'react';
 import {
   Sidebar,
@@ -17,7 +17,8 @@ import {
   DropdownMenuTrigger,
 } from '~/components/ui/dropdown-menu';
 import { Button } from '~/components/ui/button';
-import { NavLink } from '@remix-run/react';
+import { NavLink, useNavigate } from '@remix-run/react';
+import { Card, CardContent } from './ui/card';
 
 const mainNavItems = [
   { title: 'Home', url: '/dashboard/index', icon: Home },
@@ -29,6 +30,9 @@ export default function DashboardSidebar() {
   const { state } = useSidebar();
   const [selectedLanguage, setSelectedLanguage] = useState('EN');
   const collapsed = state === 'collapsed';
+  const navigate = useNavigate();
+
+  const handleFavouritesRedirect = (RSN: string) => navigate(`/dashboard/player/${RSN}`);
 
   const NavItem = ({ item, isSubItem = false }: { item: any; isSubItem?: boolean }) => {
     const IconComponent =
@@ -60,7 +64,7 @@ export default function DashboardSidebar() {
   return (
     <Sidebar>
       <SidebarContent className="flex flex-col h-full">
-      <div className="h-16 px-4 border-b border-sidebar-border flex items-center justify-between">
+        <div className="h-16 px-4 border-b border-sidebar-border flex items-center justify-between">
           <div className="flex items-center gap-2">
             <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
               <span className="text-primary-foreground font-bold text-sm">N</span>
@@ -76,16 +80,16 @@ export default function DashboardSidebar() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setSelectedLanguage("EN")}>
+                <DropdownMenuItem onClick={() => setSelectedLanguage('EN')}>
                   English
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setSelectedLanguage("ES")}>
+                <DropdownMenuItem onClick={() => setSelectedLanguage('ES')}>
                   Español
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setSelectedLanguage("FR")}>
+                <DropdownMenuItem onClick={() => setSelectedLanguage('FR')}>
                   Français
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setSelectedLanguage("DE")}>
+                <DropdownMenuItem onClick={() => setSelectedLanguage('DE')}>
                   Deutsch
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -103,6 +107,31 @@ export default function DashboardSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+
+      <div className="mt-auto p-4 space-y-4">
+        {!collapsed && (
+          <>
+            <Card>
+              <CardContent className="p-3">
+                <div className="flex items-center gap-2 mb-2">
+                  <Heart className="h-4 w-4 text-primary" />
+                  <span className="text-sm font-medium">Favourites</span>
+                </div>
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  {/* this is an example user */}
+                  <div
+                    className="flex justify-between cursor-pointer hover:text-primary transition"
+                    onClick={() => handleFavouritesRedirect(`Kelcei`)}
+                  >
+                    <span>Kelcei</span>
+                    <span>2 hours ago</span>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </div>
     </Sidebar>
   );
 }

--- a/app/contexts/favourites.tsx
+++ b/app/contexts/favourites.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type FavouritesContextType = {
+  favourites: string[];
+  addFavourite: (RSN: string) => void;
+  removeFavourite: (RSN: string) => void;
+};
+
+const STORAGE_KEY = 'favouriteProfiles';
+
+const FavouritesContext = createContext<FavouritesContextType | undefined>(undefined);
+
+export function FavouritesProvider({ children }: { children: React.ReactNode }) {
+  const [favourites, setFavourites] = useState<string[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setFavourites(JSON.parse(stored));
+      } catch {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(favourites));
+  }, [favourites]);
+
+  function addFavourite(RSN: string) {
+    setFavourites((prev) => {
+      if (prev.some((p) => p === RSN)) return prev;
+      return [...prev, RSN];
+    });
+  }
+
+  function removeFavourite(RSN: string) {
+    setFavourites((prev) => prev.filter((p) => p !== RSN));
+  }
+
+  return (
+    <FavouritesContext.Provider value={{ favourites, addFavourite, removeFavourite }}>
+      {children}
+    </FavouritesContext.Provider>
+  );
+}
+
+export function useFavourites() {
+  const context = useContext(FavouritesContext);
+  if (!context) throw new Error('useFavourites used outside of Favourites context');
+  return context;
+}

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -2,20 +2,23 @@ import { Outlet } from '@remix-run/react';
 import DashboardSidebar from '~/components/sidebar';
 import DashboardTopbar from '~/components/topbar';
 import { SidebarProvider } from '~/components/ui/sidebar';
+import { FavouritesProvider } from '~/contexts/favourites';
 
 export default function DashboardLayout() {
   return (
     <>
       <SidebarProvider>
-        <div className="min-h-screen flex w-full bg-background">
-          <DashboardSidebar />
-          <div className="flex-1 flex flex-col min-w-0">
-            <DashboardTopbar />
-            <main className="flex-1 p-3 md:p-6 animate-fade-in overflow-auto relative">
-              <Outlet />
-            </main>
+        <FavouritesProvider>
+          <div className="min-h-screen flex w-full bg-background">
+            <DashboardSidebar />
+            <div className="flex-1 flex flex-col min-w-0">
+              <DashboardTopbar />
+              <main className="flex-1 p-3 md:p-6 animate-fade-in overflow-auto relative">
+                <Outlet />
+              </main>
+            </div>
           </div>
-        </div>
+        </FavouritesProvider>
       </SidebarProvider>
     </>
   );


### PR DESCRIPTION
### Description

This pull request introduces a new "Favourites" feature integrated into the sidebar and player profile components, enhancing user experience by allowing users to manage and quickly access their favourite profiles.

**Key changes include:**

- **Favourites Context:** Added a `FavouritesContext` to centrally manage favourite profiles by their RSNs. The context persists favourites in `localStorage` to maintain state across sessions and provides functions to add or remove favourites while preventing duplicates.

- **Dashboard Integration:** Wrapped the dashboard layout with `FavouritesProvider` to enable global access to the favourites context, ensuring consistent state management across components.

- **Sidebar Enhancements:** Updated the sidebar to display a dynamic list of favourite profiles fetched from the favourites context. When no favourites exist, a fallback message "No favourites yet" is shown, improving relevance and user feedback.

- **Player Profile Update:** Added a favourite button on player profile pages, allowing users to easily add or remove profiles from their favourites.

These improvements provide a seamless way for users to curate and navigate their favourite profiles directly from the sidebar, improving accessibility and personalization within the app.