### PR TITLE
feat(dashboard): add weekly XP trends and top gainers cards

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -13,6 +13,15 @@ export function toJsonValue<T>(data: T): unknown {
   return JSON.parse(JSON.stringify(data));
 }
 
+export const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export function formatXp(value: number): string {
+  if (value >= 1_000_000_000) return (value / 1_000_000_000).toFixed(1) + 'B';
+  if (value >= 1_000_000) return (value / 1_000_000).toFixed(1) + 'M';
+  if (value >= 1_000) return (value / 1_000).toFixed(1) + 'K';
+  return value.toString();
+}
+
 export function sanitizeBigInts(obj: any): any {
   if (typeof obj === 'bigint') {
     return obj.toString();


### PR DESCRIPTION
Add two new cards to the dashboard: a line chart showing total XP gained
across all tracked players over the past week, and a list of top XP gainers
in the last 24 hours. These provide users with better insights into player
progress and recent activity.

Implement a new service function to fetch total XP per day of the week from
player snapshots, supporting the weekly trends visualization.