### PR TITLE
feat(dashboard): display player clan name on overview tab

### DIFF
--- a/app/routes/dashboard.player.$rsn/route.tsx
+++ b/app/routes/dashboard.player.$rsn/route.tsx
@@ -19,7 +19,7 @@ import {
 import { prisma } from '~/services/prisma.server';
 import { sanitizeBigInts } from '~/lib/utils';
 import { PlayerData } from '~/~types/PlayerData';
-import { RuneMetrics } from '~/services/runescape.server';
+import { RuneMetrics, Runescape } from '~/services/runescape.server';
 import Header from './header';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import OverviewTab from './tabs/overview';
@@ -50,6 +50,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
     getTrackedDaysByUsername(rsn),
   ]);
 
+  const clanName = await Runescape.getPlayerClanName(rsn);
+
   return {
     player,
     stats: {
@@ -57,6 +59,9 @@ export async function loader({ params }: LoaderFunctionArgs) {
       dailyXP,
       dailyLevels,
       daysTracked,
+    },
+    clan: {
+      clanName
     },
     meta,
     chatheadURI: RuneMetrics.getChatheadURI(rsn),

--- a/app/routes/dashboard.player.$rsn/tabs/overview.tsx
+++ b/app/routes/dashboard.player.$rsn/tabs/overview.tsx
@@ -16,11 +16,12 @@ export interface OverviewTabProps {
   data: {
     player: PlayerData;
     stats: any;
+    clan: any;
   };
 }
 
 export default function OverviewTab(props: Readonly<OverviewTabProps>) {
-  const { player, stats } = props.data;
+  const { player, stats, clan } = props.data;
 
   let questPoints = 0;
   player.Quests.Quests.filter((q) => q.Status === 'COMPLETED').forEach(
@@ -40,7 +41,7 @@ export default function OverviewTab(props: Readonly<OverviewTabProps>) {
           <CardContent className="p-4">
             <div className="text-center">
               <Users className="h-5 w-5 mx-auto mb-2 text-primary" />
-              <div className="text-lg font-bold">N/A</div>
+              <div className="text-lg font-bold">{clan.clanName}</div>
               <div className="text-xs text-muted-foreground">Clan</div>
             </div>
           </CardContent>

--- a/app/services/runescape.server.ts
+++ b/app/services/runescape.server.ts
@@ -102,3 +102,19 @@ export class RuneMetrics {
     return `https://secure.runescape.com/m=avatar-rs/${encodeURIComponent(username)}/chat.png`;
   }
 }
+
+export class Runescape {
+  private static BASE_URL = 'https://secure.runescape.com';
+
+  static async getPlayerClanName(username: string) {
+    const url =
+      this.BASE_URL +
+      `/m=website-data/playerDetails.ws?names=%5B%22${encodeURIComponent(username)}%22%5D&callback=jQuery000000000000000_0000000000&_=0`;
+
+    const result = await fetch(url);
+    const clan = JSON.parse(
+      (await result.text()).replace('jQuery000000000000000_0000000000(', '').replace(');', ''),
+    )[0].clan;
+    return clan;
+  }
+}


### PR DESCRIPTION
Add fetching of player clan name from RuneScape API in the loader to
include clan data in the dashboard. Update the overview tab to show
the clan name instead of "N/A". This improves the player profile by
providing more complete and relevant information.