### PR TITLE
fix(runescape): handle errors in getPlayerClanName method

### DIFF
--- a/app/services/runescape.server.ts
+++ b/app/services/runescape.server.ts
@@ -106,15 +106,20 @@ export class RuneMetrics {
 export class Runescape {
   private static BASE_URL = 'https://secure.runescape.com';
 
+  // TODO: Cache and save clan data to database
   static async getPlayerClanName(username: string) {
     const url =
       this.BASE_URL +
       `/m=website-data/playerDetails.ws?names=%5B%22${encodeURIComponent(username)}%22%5D&callback=jQuery000000000000000_0000000000&_=0`;
 
     const result = await fetch(url);
-    const clan = JSON.parse(
-      (await result.text()).replace('jQuery000000000000000_0000000000(', '').replace(');', ''),
-    )[0].clan;
-    return clan;
+    try {
+      const clan = JSON.parse(
+        (await result.text()).replace('jQuery000000000000000_0000000000(', '').replace(');', ''),
+      )[0].clan;
+      return clan;
+    } catch {
+      return 'N/A';
+    }
   }
 }


### PR DESCRIPTION
Add try-catch block to safely parse clan data from the API response.
Return 'N/A' if parsing fails or data is unavailable to prevent runtime
errors. Add a TODO comment to cache and save clan data to the database
for future improvements.