### PR TITLE
leaderboards

### DIFF
--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -65,7 +65,7 @@ export default function DashboardSidebar() {
   };
 
   return (
-    <Sidebar>
+    <Sidebar collapsible='icon'>
       <SidebarContent className="flex flex-col h-full">
         <div className="h-16 px-4 border-b border-sidebar-border flex items-center justify-between">
           <div className="flex items-center gap-2">

--- a/app/routes/dashboard.leaderboards/route.tsx
+++ b/app/routes/dashboard.leaderboards/route.tsx
@@ -1,0 +1,90 @@
+import { LoaderFunctionArgs } from '@remix-run/node';
+import { Calendar, Crown, TrendingUp, Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
+import TopSkills from './top-skills';
+import TopPlayers from './top-players';
+import { useState } from 'react';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  return null;
+}
+
+export default function Leaderboards() {
+  const { t } = useTranslation();
+
+  const [timeFilter, setTimeFilter] = useState('all_time');
+  const [skillFilter, setSkillFilter] = useState('overall');
+
+  const stats = [
+    {
+      title: t('pages.leaderboards.cards.total_players.title'),
+      description: t('pages.leaderboards.cards.total_players.description'),
+      value: '0',
+      icon: Users,
+    },
+    {
+      title: t('pages.leaderboards.cards.maxed_players.title'),
+      description: t('pages.leaderboards.cards.maxed_players.description'),
+      value: '0',
+      icon: Crown,
+    },
+    {
+      title: t('pages.leaderboards.cards.weekly_xp.title'),
+      description: t('pages.leaderboards.cards.weekly_xp.description'),
+      value: '0',
+      icon: TrendingUp,
+    },
+    {
+      title: t('pages.leaderboards.cards.active_today.title'),
+      description: t('pages.leaderboards.cards.active_today.description'),
+      value: '0',
+      icon: Calendar,
+    },
+  ];
+
+  const sampleData = [
+    { skill: 'Necromancy', players: 16 },
+    { skill: 'Attack', players: 5 },
+    { skill: 'Defence', players: 3 },
+    { skill: 'Runecrafting', players: 2 },
+    { skill: 'Constitution', players: 1 },
+    { skill: 'Crafting', players: 1 },
+    { skill: 'Strength', players: 1 },
+    { skill: 'Divination', players: 0 },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center space-y-2">
+        <h1 className="text-3xl font-bold">{t('pages.leaderboards.title')}</h1>
+        <p className="text-muted-foreground">{t('pages.leaderboards.description')}</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {stats.map((stat, index) => (
+          <Card
+            key={stat.title}
+            className="transition-smooth hover:shadow-lg animate-fade-in"
+            style={{ animationDelay: `${index * 0.1}s` }}
+          >
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {stat.title}
+              </CardTitle>
+              <stat.icon className="h-4 w-4 text-primary" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stat.value}</div>
+              <p className="text-xs text-muted-foreground mt-1">{stat.description}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <TopSkills data={sampleData} />
+
+      <TopPlayers filters={{ time: timeFilter, skill: skillFilter }} data={{}} />
+    </div>
+  );
+}

--- a/app/routes/dashboard.leaderboards/top-players.tsx
+++ b/app/routes/dashboard.leaderboards/top-players.tsx
@@ -1,0 +1,35 @@
+import { Crown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
+
+export interface TopPlayersProps {
+  data: {};
+  filters: {
+    time: string;
+    skill: string;
+  };
+}
+
+export default function TopPlayers(props: Readonly<TopPlayersProps>) {
+  const { t } = useTranslation();
+
+  return (
+    <Card className='animate-fade-in'>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2'>
+          <Crown className='h-5 w-5 text-primary' />
+          {t('pages.leaderboards.top_players.title')} -{' '}
+          {t(`pages.leaderboards.top_players.time_filters.${props.filters.time}`)}
+        </CardTitle>
+        <CardDescription>
+          {props.filters.skill === 'overall'
+            ? t('pages.leaderboards.top_players.skill_filters.overall')
+            : `${props.filters.skill} ${t('pages.leaderboards.top_players.skill_filters.leaderboard')}`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        sybau ✌️
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/routes/dashboard.leaderboards/top-players.tsx
+++ b/app/routes/dashboard.leaderboards/top-players.tsx
@@ -1,34 +1,136 @@
+import { Form, useNavigate, useSearchParams } from '@remix-run/react';
 import { Crown } from 'lucide-react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Avatar, AvatarFallback, AvatarImage } from '~/components/ui/avatar';
+import { Badge } from '~/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+import { formatBigInt } from '~/lib/utils';
+import { SkillMap } from '~/~constants/Skills';
 
 export interface TopPlayersProps {
-  data: {};
+  data: {
+    leaderboard: { rank: number; player: string; xp: number; gained: number; level: number }[];
+  };
   filters: {
-    time: string;
-    skill: string;
+    time: [string, Dispatch<SetStateAction<string>>];
+    skill: [string, Dispatch<SetStateAction<string>>];
   };
 }
 
 export default function TopPlayers(props: Readonly<TopPlayersProps>) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [searchParameters] = useSearchParams();
+
+  const [timeFilter, setTimeFilter] = props.filters.time;
+  const [skillFilter, setSkillFilter] = props.filters.skill;
+
+  const handleSkillParameterChange = (value: string) => {
+    const params = new URLSearchParams(searchParameters);
+    setSkillFilter(value);
+    params.set('skill', value);
+    navigate(`?${params.toString()}`);
+  };
+
+  const handleTimeParameterChange = (value: string) => {
+    const params = new URLSearchParams(searchParameters);
+    setTimeFilter(value);
+    params.set('time', value);
+    navigate(`?${params.toString()}`);
+  };
 
   return (
-    <Card className='animate-fade-in'>
+    <Card className="animate-fade-in">
       <CardHeader>
-        <CardTitle className='flex items-center gap-2'>
-          <Crown className='h-5 w-5 text-primary' />
+        <CardTitle className="flex items-center gap-2">
+          <Crown className="h-5 w-5 text-primary" />
           {t('pages.leaderboards.top_players.title')} -{' '}
-          {t(`pages.leaderboards.top_players.time_filters.${props.filters.time}`)}
+          {t(`pages.leaderboards.top_players.time_filters.${timeFilter}`)}
         </CardTitle>
         <CardDescription>
-          {props.filters.skill === 'overall'
+          {skillFilter === 'overall'
             ? t('pages.leaderboards.top_players.skill_filters.overall')
-            : `${props.filters.skill} ${t('pages.leaderboards.top_players.skill_filters.leaderboard')}`}
+            : `${skillFilter.charAt(0).toUpperCase() + skillFilter.slice(1)} ${t('pages.leaderboards.top_players.skill_filters.leaderboard')}`}
         </CardDescription>
       </CardHeader>
       <CardContent>
-        sybau ✌️
+        <Form method="get" className="flex gap-4 mb-4">
+          <Select name="time" value={timeFilter} onValueChange={handleTimeParameterChange}>
+            <SelectTrigger className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all_time">
+                {t('pages.leaderboards.top_players.time_filters.all_time')}
+              </SelectItem>
+              <SelectItem value="month">
+                {t('pages.leaderboards.top_players.time_filters.month')}
+              </SelectItem>
+              <SelectItem value="week">
+                {t('pages.leaderboards.top_players.time_filters.week')}
+              </SelectItem>
+              <SelectItem value="today">
+                {t('pages.leaderboards.top_players.time_filters.today')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <Select name="skill" value={skillFilter} onValueChange={handleSkillParameterChange}>
+            <SelectTrigger className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="overall">Overall</SelectItem>
+              {Object.entries(SkillMap).map(([_, name]) => (
+                <SelectItem value={name.toLowerCase()}>{name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Form>
+        <div className="space-y-3">
+          {props.data.leaderboard.map((data, idx) => (
+            <div
+              key={data.rank}
+              className="flex items-center justify-between p-4 rounded-lg border hover:bg-muted/50 transition-smooth animate-fade-in cursor-pointer"
+              style={{ animationDelay: `${idx * 0.05}s` }}
+              onClick={() => navigate(`/dashboard/player/${data.player}`)}
+            >
+              <div className="flex items-center gap-4">
+                <Avatar className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold">
+                  <AvatarImage
+                    src={`https://secure.runescape.com/m=avatar-rs/${data.player}/chat.png`}
+                    alt={`${data.player}'s avatar`}
+                  />
+                  <AvatarFallback className="w-16 h-16 sm:w-20 sm:h-20 bg-primary text-xl sm:text-2xl font-bold text-primary-foreground">
+                    {data.player.charAt(0).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <div className="font-medium text-lg">{data.player}</div>
+                  <div className="text-sm text-muted-foreground">Total Level: {data.level}</div>
+                </div>
+              </div>
+              <div className="text-right space-y-1">
+                <div className="font-bold text-lg">{formatBigInt(data.xp)} XP</div>
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-xs">
+                    +{formatBigInt(data.gained)} XP
+                  </Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {t(`pages.leaderboards.top_players.time_filters.${timeFilter}`)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       </CardContent>
     </Card>
   );

--- a/app/routes/dashboard.leaderboards/top-skills.tsx
+++ b/app/routes/dashboard.leaderboards/top-skills.tsx
@@ -1,0 +1,35 @@
+import { Trophy } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
+
+export interface TopSkillsProps {
+  data: { skill: string; players: number }[];
+}
+
+export default function TopSkills({ data }: Readonly<TopSkillsProps>) {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="animate-fade-in">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Trophy className="h-5 w-5 text-primary" />
+          {t('pages.leaderboards.top_skills.title')}
+        </CardTitle>
+        <CardDescription>{t('pages.leaderboards.top_skills.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+            <XAxis dataKey="skill" stroke="#9CA3AF" />
+            <YAxis stroke="#9CA3AF" />
+            <Tooltip contentStyle={{ backgroundColor: '#1F2937', border: '1px solid #374151' }} />
+            <Bar dataKey="players" fill="#a29bfe" />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -94,6 +94,45 @@
           }
         }
       }
+    },
+    "leaderboards": {
+      "title": "Leaderboards",
+      "description": "Top RS3 players ranked by total experience and skill levels",
+      "cards": {
+        "total_players": {
+          "title": "Total Players",
+          "description": "Currently tracked"
+        },
+        "maxed_players": {
+          "title": "Maxed Players",
+          "description": "99 in every skill"
+        },
+        "weekly_xp": {
+          "title": "XP This Week",
+          "description": "Community total"
+        },
+        "active_today": {
+          "title": "Active Today",
+          "description": "Tracked players online"
+        }
+      },
+      "top_skills": {
+        "title": "Most Popular Skills",
+        "description": "Number of players with 99+ in each skill"
+      },
+      "top_players": {
+        "title": "Top Players",
+        "time_filters": {
+          "all_time": "All Time",
+          "month": "This Month",
+          "week": "This Week",
+          "today": "Today"
+        },
+        "skill_filters": {
+          "overall": "Overall XP leaderboard",
+          "leaderboard": "leaderboard"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Summary

This pull request introduces a new **Leaderboards** dashboard feature along with enhancements to the sidebar UI.

### Changes

- Added a collapsible sidebar with an icon toggle to improve navigation and save screen space.
- Created a new leaderboards dashboard route displaying:
  - Key stats cards (maxed players, weekly XP, active players, total tracked players)
  - Top skills bar chart
  - Top players section
- Developed `TopSkills` and `TopPlayers` components to visualize skill popularity and player rankings.
- Implemented server-side data loading with a loader fetching real leaderboard data.
- Added URL query parameter parsing and validation for time and skill filters, syncing filter state with the URL.
- Enhanced the player model with a `getMaxedPlayers` query to count players with all skills at level 99.
- Replaced sample data with real data to improve accuracy and user control over leaderboard views.
- Added translation support for UI text in the leaderboard components.

### Impact

These changes lay the foundation for dynamic and interactive leaderboards, providing users with detailed insights into player and skill rankings while improving overall dashboard usability.