### PR TITLE
refresh-data

### DIFF
--- a/app/components/ui/sonner.tsx
+++ b/app/components/ui/sonner.tsx
@@ -1,0 +1,29 @@
+import { useTheme } from "next-themes"
+import { Toaster as Sonner } from "sonner"
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/app/routes/dashboard.player.$rsn/header.tsx
+++ b/app/routes/dashboard.player.$rsn/header.tsx
@@ -9,17 +9,22 @@ import { Card, CardHeader } from '~/components/ui/card';
 import { Tooltip } from '~/components/ui/tooltip';
 import { PlayerData } from '~/~types/PlayerData';
 import { useTranslation } from 'react-i18next';
+import { formatDistance } from 'date-fns';
+import RefreshProfileButton from './refresh-button';
 
 export interface HeaderComponentProps {
   data: {
     player: PlayerData;
+    refreshInfo: {
+      refreshable: boolean;
+      refreshable_at: Date | null;
+    };
     chatheadURI: string;
   };
 }
 
 export default function Header(props: Readonly<HeaderComponentProps>) {
-  const { player } = props.data;
-  const fetcher = useFetcher();
+  const { player, refreshInfo } = props.data;
   const { t } = useTranslation();
 
   return (
@@ -47,29 +52,7 @@ export default function Header(props: Readonly<HeaderComponentProps>) {
             </div>
           </div>
           <div className="flex gap-2 w-full sm:w-auto">
-            <fetcher.Form method="get" action={`/api/refresh/${player.Username}`}>
-              <Tooltip>
-                <TooltipTrigger>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="flex items-center gap-2 flex-1 sm:flex-none"
-                    type="submit"
-                    disabled={true}
-                  >
-                    <RefreshCw className="h-4 w-4" />
-                    <span className="hidden sm:inline">{t('pages.player_profile.refresh')}</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {/* <p>
-                    {canRefresh
-                      ? 'Refresh this users data'
-                      : formatDistance(now, refreshTimestampDate, { includeSeconds: true })}
-                  </p> */}
-                </TooltipContent>
-              </Tooltip>
-            </fetcher.Form>
+            <RefreshProfileButton refreshInfo={props.data.refreshInfo} username={player.Username}/>
             <FavouriteProfileButton RSN={player.Username} />
           </div>
         </div>

--- a/app/routes/dashboard.player.$rsn/refresh-button.tsx
+++ b/app/routes/dashboard.player.$rsn/refresh-button.tsx
@@ -1,0 +1,78 @@
+import { useFetcher } from '@remix-run/react';
+import { formatDistance } from 'date-fns';
+import { t } from 'i18next';
+import { RefreshCw } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '~/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip';
+import type { RefreshProfileResponse } from '~/~types/API';
+
+export interface RefreshProfileButtonProps {
+  username: string;
+  refreshInfo: {
+    refreshable: boolean;
+    refreshable_at: Date | null;
+  };
+}
+
+export default function RefreshProfileButton(props: Readonly<RefreshProfileButtonProps>) {
+  const { username, refreshInfo } = props;
+  const fetcher = useFetcher<RefreshProfileResponse>();
+
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const shownToastRef = useRef(false);
+
+  useEffect(() => {
+    if (fetcher.state === 'submitting') {
+      setIsRefreshing(true);
+      shownToastRef.current = false;
+    }
+
+    if (fetcher.state === 'idle' && fetcher.data && !shownToastRef.current) {
+      shownToastRef.current = true;
+
+      setTimeout(() => {
+        setIsRefreshing(false);
+      }, 500);
+
+      if (fetcher.data.success) {
+        toast.success(t('pages.player_profile.refresh_success'));
+      } else {
+        toast.error(t('pages.player_profile.refresh_failed'));
+      }
+    }
+  }, [fetcher.state, fetcher.data]);
+
+  const now = new Date();
+
+  return (
+    <fetcher.Form method="post" action={`/api/refresh/${username}`}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex items-center gap-2 flex-1 sm:flex-none"
+            type="submit"
+            disabled={!refreshInfo.refreshable || isRefreshing}
+          >
+            <RefreshCw className="h-4 w-4" />
+            <span className="hidden sm:inline">
+              {isRefreshing
+                ? t('pages.player_profile.refreshing')
+                : t('pages.player_profile.refresh')}
+            </span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            {refreshInfo.refreshable
+              ? t('pages.player_profile.refresh_tooltip')
+              : formatDistance(now, refreshInfo.refreshable_at!, { includeSeconds: true })}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </fetcher.Form>
+  );
+}

--- a/app/routes/dashboard.player.$rsn/route.tsx
+++ b/app/routes/dashboard.player.$rsn/route.tsx
@@ -10,6 +10,7 @@ import {
 import PlayerNotFound from './not-found';
 import { Card, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
 import {
+  canRefresh,
   getDailyLevelIncreases,
   getDailyXpIncreases,
   getFreshestData,
@@ -44,17 +45,19 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
   const player: PlayerData = sanitizeBigInts(data);
 
-  const [weeklyXp, dailyXP, dailyLevels, daysTracked] = await Promise.all([
+  const [weeklyXp, dailyXP, dailyLevels, daysTracked, refreshInfo] = await Promise.all([
     getWeeklyXpByDay(rsn),
     getDailyXpIncreases(rsn),
     getDailyLevelIncreases(rsn),
     getTrackedDaysByUsername(rsn),
+    canRefresh(rsn),
   ]);
 
   const clanName = (await Runescape.getPlayerClanName(rsn)) ?? 'N/A';
 
   return {
     player,
+    refreshInfo,
     stats: {
       weeklyXp,
       dailyXP,

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -3,8 +3,9 @@ import DashboardSidebar from '~/components/sidebar';
 import DashboardTopbar from '~/components/topbar';
 import { SidebarProvider } from '~/components/ui/sidebar';
 import { FavouritesProvider } from '~/contexts/favourites';
-import { I18nextProvider } from "react-i18next";
-import i18n from "../i18n";
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
+import { Toaster } from 'sonner';
 
 export default function DashboardLayout() {
   return (
@@ -18,6 +19,7 @@ export default function DashboardLayout() {
                 <DashboardTopbar />
                 <main className="flex-1 p-3 md:p-6 animate-fade-in overflow-auto relative">
                   <Outlet />
+                  <Toaster theme='system'/>
                 </main>
               </div>
             </div>

--- a/app/~types/API.ts
+++ b/app/~types/API.ts
@@ -1,0 +1,4 @@
+export type RefreshProfileResponse = {
+  success: boolean;
+  message: string;
+};

--- a/package.json
+++ b/package.json
@@ -49,11 +49,13 @@
     "i18next-http-backend": "^3.0.2",
     "isbot": "^4.1.0",
     "lucide-react": "^0.525.0",
+    "next-themes": "^0.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^15.6.0",
     "recharts": "^3.0.2",
     "redis": "^5.5.6",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@18.3.1)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -95,6 +98,9 @@ importers:
       redis:
         specifier: ^5.5.6
         version: 5.5.6
+      sonner:
+        specifier: ^2.0.6
+        version: 2.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -3573,6 +3579,12 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -4272,6 +4284,12 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  sonner@2.0.6:
+    resolution: {integrity: sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8627,6 +8645,11 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  next-themes@0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -9409,6 +9432,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  sonner@2.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -49,6 +49,10 @@
     },
     "player_profile": {
       "refresh": "Refresh",
+      "refreshing": "Refreshing...",
+      "refresh_tooltip": "Refresh this players data",
+      "refresh_success": "Successfully refreshed this players data",
+      "refresh_failed": "Failed to refresh this players data. Please try again, or contact us on discord",
       "favourited": "Favourited",
       "favourite": "Favourite",
       "online": "Online",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -49,6 +49,10 @@
     },
     "player_profile": {
       "refresh": "Actualizar",
+      "refreshing": "Refreshing...",
+      "refresh_tooltip": "Refresh this players data",
+      "refresh_success": "Successfully refreshed this players data",
+      "refresh_failed": "Failed to refresh this players data. Please try again, or contact us on discord",
       "favourited": "Favoritos",
       "favourite": "Favorito",
       "online": "En Línea",


### PR DESCRIPTION
### Summary

This pull request introduces a comprehensive enhancement to the player profile data refresh functionality, improving both backend logic and user experience.

### Changes

- **Player refresh logic**: Updated `canRefresh` to return detailed refresh timing information (not just a boolean), based on Redis key TTL. This allows clients to know exactly when a refresh will be possible, improving lock handling and decision making.
- **Dashboard integration**: The player stats loader now fetches and exposes refresh availability info, enabling the UI to conditionally display refresh options.
- **UI improvements**:
  - Added a new `RefreshProfileButton` component in the player header that allows manual profile refreshes.
  - Integrated the Sonner toast library with `next-themes` support for consistent, theme-aware toast notifications.
  - Toasts provide clear success and failure feedback on refresh attempts.
- **Internationalization**: Added new i18n keys for refresh status messages in English and Spanish to improve user feedback and accessibility.
- **Dependencies**: Updated dependencies to include `sonner` and `next-themes` with compatible React versions.

### Benefits

- Users receive precise feedback on when they can refresh player data.
- Manual refreshes are enabled with clear success/failure notifications.
- The UI adapts to user theme preferences for a polished look.
- Overall, this improves data accuracy, user interaction, and interface clarity around player profile refreshes.