### PR TITLE
feat: add dynamic meta titles for dashboard and player routes

### DIFF
--- a/app/routes/dashboard.player.$rsn/route.tsx
+++ b/app/routes/dashboard.player.$rsn/route.tsx
@@ -1,6 +1,7 @@
 import { LoaderFunctionArgs } from '@remix-run/node';
 import {
   isRouteErrorResponse,
+  MetaFunction,
   useLoaderData,
   useLocation,
   useNavigation,
@@ -29,6 +30,11 @@ import QuestsTab from './tabs/quests';
 import { useState, useRef, useEffect } from 'react';
 import { PlayerProfileSkeleton } from './skeleton';
 import { useTranslation } from 'react-i18next';
+
+export const meta: MetaFunction = () => {
+  const params = useParams();
+  return [{ title: `${params.rsn} | Nexus` }];
+};
 
 export async function loader({ params }: LoaderFunctionArgs) {
   const rsn = params.rsn?.toLowerCase().trim();
@@ -113,13 +119,13 @@ export default function PlayerProfile() {
       <Tabs defaultValue="overview" className="space-y-4 sm:space-y-6">
         <TabsList className="grid w-full grid-cols-3 h-auto">
           <TabsTrigger value="overview" className="text-xs sm:text-sm py-2">
-            {t("pages.player_profile.tabs.overview.name")}
+            {t('pages.player_profile.tabs.overview.name')}
           </TabsTrigger>
           <TabsTrigger value="skills" className="text-xs sm:text-sm py-2">
-          {t("pages.player_profile.tabs.skills.name")}
+            {t('pages.player_profile.tabs.skills.name')}
           </TabsTrigger>
           <TabsTrigger value="quests" className="text-xs sm:text-sm py-2">
-          {t("pages.player_profile.tabs.quests.name")}
+            {t('pages.player_profile.tabs.quests.name')}
           </TabsTrigger>
         </TabsList>
 

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from '@remix-run/react';
+import { MetaFunction, Outlet } from '@remix-run/react';
 import DashboardSidebar from '~/components/sidebar';
 import DashboardTopbar from '~/components/topbar';
 import { SidebarProvider } from '~/components/ui/sidebar';
@@ -6,6 +6,10 @@ import { FavouritesProvider } from '~/contexts/favourites';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../i18n';
 import { Toaster } from 'sonner';
+
+export const meta: MetaFunction = () => {
+  return [{ title: 'Nexus' }];
+};
 
 export default function DashboardLayout() {
   return (
@@ -19,7 +23,7 @@ export default function DashboardLayout() {
                 <DashboardTopbar />
                 <main className="flex-1 p-3 md:p-6 animate-fade-in overflow-auto relative">
                   <Outlet />
-                  <Toaster theme='system'/>
+                  <Toaster theme="system" />
                 </main>
               </div>
             </div>


### PR DESCRIPTION
Add MetaFunction implementations to set page titles dynamically based
on the current route. The dashboard route now has a static title
"Nexus", while the player profile route uses the player's RSN to create
a personalized title. This improves SEO and user experience by
providing relevant page titlesfix: unify quote style in player profile tabs

Update translation key strings in PlayerProfile tabs to use single
quotes consistently, improving code style and readability.