### PR TITLE
feat(sidebar): localize Competitions label in sidebar menu

### DIFF
--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -155,7 +155,7 @@ export default function DashboardSidebar() {
                 >
                   <div className="flex items-center">
                     <Trophy className="mr-4 h-4 w-4" />
-                    {!collapsed && <span>Competitions</span>}
+                    {!collapsed && <span>{t('sidebar.competitions')}</span>}
                   </div>
                   {!collapsed && competitionsOpen ? (
                     <ChevronUp className="h-4 w-4" />


### PR DESCRIPTION
Replace the static "Competitions" text with a translated string using
the i18n `t` function. This change enables localization support for the
sidebar, improving usability for users in different languages.